### PR TITLE
[#501] Add `equals` and `hashCode` implementations to PSI class wrappers

### DIFF
--- a/java/src/main/kotlin/org/jetbrains/research/testspark/java/JavaPsiClassWrapper.kt
+++ b/java/src/main/kotlin/org/jetbrains/research/testspark/java/JavaPsiClassWrapper.kt
@@ -124,5 +124,6 @@ class JavaPsiClassWrapper(
         return qualifiedName == other.qualifiedName && qualifiedName.isNotEmpty()
     }
 
-    override fun hashCode(): Int = qualifiedName.hashCode()
+    override fun hashCode(): Int =
+        if (qualifiedName.isNotEmpty()) qualifiedName.hashCode() else System.identityHashCode(this)
 }

--- a/java/src/main/kotlin/org/jetbrains/research/testspark/java/JavaPsiClassWrapper.kt
+++ b/java/src/main/kotlin/org/jetbrains/research/testspark/java/JavaPsiClassWrapper.kt
@@ -124,6 +124,5 @@ class JavaPsiClassWrapper(
         return qualifiedName == other.qualifiedName && qualifiedName.isNotEmpty()
     }
 
-    override fun hashCode(): Int =
-        if (qualifiedName.isNotEmpty()) qualifiedName.hashCode() else System.identityHashCode(this)
+    override fun hashCode(): Int = if (qualifiedName.isNotEmpty()) qualifiedName.hashCode() else System.identityHashCode(this)
 }

--- a/java/src/main/kotlin/org/jetbrains/research/testspark/java/JavaPsiClassWrapper.kt
+++ b/java/src/main/kotlin/org/jetbrains/research/testspark/java/JavaPsiClassWrapper.kt
@@ -117,4 +117,12 @@ class JavaPsiClassWrapper(
 
         return !containsImport
     }
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other !is JavaPsiClassWrapper) return false
+        return qualifiedName == other.qualifiedName && qualifiedName.isNotEmpty()
+    }
+
+    override fun hashCode(): Int = qualifiedName.hashCode()
 }

--- a/kotlin/src/main/kotlin/org/jetbrains/research/testspark/kotlin/KotlinPsiClassWrapper.kt
+++ b/kotlin/src/main/kotlin/org/jetbrains/research/testspark/kotlin/KotlinPsiClassWrapper.kt
@@ -170,6 +170,5 @@ class KotlinPsiClassWrapper(
         return qualifiedName == other.qualifiedName && qualifiedName.isNotEmpty()
     }
 
-    override fun hashCode(): Int =
-        if (qualifiedName.isNotEmpty()) qualifiedName.hashCode() else System.identityHashCode(this)
+    override fun hashCode(): Int = if (qualifiedName.isNotEmpty()) qualifiedName.hashCode() else System.identityHashCode(this)
 }

--- a/kotlin/src/main/kotlin/org/jetbrains/research/testspark/kotlin/KotlinPsiClassWrapper.kt
+++ b/kotlin/src/main/kotlin/org/jetbrains/research/testspark/kotlin/KotlinPsiClassWrapper.kt
@@ -170,5 +170,6 @@ class KotlinPsiClassWrapper(
         return qualifiedName == other.qualifiedName && qualifiedName.isNotEmpty()
     }
 
-    override fun hashCode(): Int = qualifiedName.hashCode()
+    override fun hashCode(): Int =
+        if (qualifiedName.isNotEmpty()) qualifiedName.hashCode() else System.identityHashCode(this)
 }

--- a/kotlin/src/main/kotlin/org/jetbrains/research/testspark/kotlin/KotlinPsiClassWrapper.kt
+++ b/kotlin/src/main/kotlin/org/jetbrains/research/testspark/kotlin/KotlinPsiClassWrapper.kt
@@ -163,4 +163,12 @@ class KotlinPsiClassWrapper(
 
         return !containsImport
     }
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other !is KotlinPsiClassWrapper) return false
+        return qualifiedName == other.qualifiedName && qualifiedName.isNotEmpty()
+    }
+
+    override fun hashCode(): Int = qualifiedName.hashCode()
 }


### PR DESCRIPTION
# Description of changes made

Implemented `equals` and `hashCode` methods in `JavaPsiClassWrapper` and `KotlinPsiClassWrapper` to ensure proper comparison and hashing based on the qualified name.

# Why is merge request needed

When the `PromptManager` gets `interestingPsiClasses` ([here](https://github.com/JetBrains-Research/TestSpark/blob/508264ef65382ebff5947d9419ce0a23cd9417a0/src/main/kotlin/org/jetbrains/research/testspark/tools/llm/generation/PromptManager.kt#L76)) using `psiHelper.getInterestingPsiClassesWithQualifiedNames`, `PsiMethodWrapper.getInterestingPsiClassesWithQualifiedNames` is called.
The `JavaPsiMethodWrapper` and `KotlinPsiMethodWrapper` create a new instance of the corresponding PsiClassWrapper for each interesting PSI class.

If the same class is added to the `MutableSet`, two items will be present because they will be two distinct instances of the `PsiClassWrapper`.

# Other notes

Fixes #501 
I can't think of any particular case where two distinct classes can have the same qualified name.

## Potential improvements
Based on data of a TGA-Pipeline run with the current version of TestSpark, duplicate class signatures has been removed from the prompt, resulting in a potentially significant improvement in performance.

<img width="566" height="449" alt="image" src="https://github.com/user-attachments/assets/dbc54dbf-868f-4d46-8c94-b5d2d566de5f" />

# What is missing?
*Please mention if anything is missing for this merge request, e.g you have decided to move something to the next merge request*

- [x] I have checked that I am merging into correct branch
