### PR TITLE
[Draft] [chore] Update Plugin for IJ 2026 compatibility

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -57,7 +57,7 @@ jobs:
         uses: actions/setup-java@v4
         with:
           distribution: zulu
-          java-version: 17
+          java-version: 21
 #          cache: gradle
 
       # Set environment variables

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,7 +25,7 @@ jobs:
         uses: actions/setup-java@v3
         with:
           distribution: zulu
-          java-version: 17
+          java-version: 21
           cache: gradle
 
       # Set environment variables

--- a/.github/workflows/run-ui-tests.yml
+++ b/.github/workflows/run-ui-tests.yml
@@ -10,7 +10,7 @@ jobs:
         uses: actions/setup-java@v3
         with:
           distribution: zulu
-          java-version: 17
+          java-version: 21
       - name: Setup FFmpeg
         uses: FedericoCarboni/setup-ffmpeg@v1
         with:
@@ -48,7 +48,7 @@ jobs:
         uses: actions/setup-java@v3
         with:
           distribution: zulu
-          java-version: 11
+          java-version: 21
       - name: Setup FFmpeg
         uses: FedericoCarboni/setup-ffmpeg@v1
         with:
@@ -92,7 +92,7 @@ jobs:
         uses: actions/setup-java@v3
         with:
           distribution: zulu
-          java-version: 11
+          java-version: 21
       - name: Setup FFmpeg
         uses: FedericoCarboni/setup-ffmpeg@v1
         with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@
 ### Added
 - Support IDEA `261.*` (IntelliJ 2026.1).
 
+### Breaking
+- Drop support for IDEA `251.*` (IntelliJ 2025.1) and earlier.  The minimal required IntelliJ version is now 2025.2!
+
 ### Changed
 - Migrate the plugin build toolchain to Java 21 (required by the 2025.1+ platform).
 - Bump IntelliJ Platform Gradle Plugin to 2.6.0 and Kotlin JVM plugin to 2.3.0.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,21 @@
 # TestSpark Changelog
 ## Unreleased
 
+## 0.5.0
+
+### Added
+- Support IDEA `261.*` (IntelliJ 2026.1).
+
+### Changed
+- Migrate the plugin build toolchain to Java 21 (required by the 2025.1+ platform).
+- Bump IntelliJ Platform Gradle Plugin to 2.6.0 and Kotlin JVM plugin to 2.3.0.
+- Bump `foojay-resolver-convention` to 1.0.0 for reliable JBR-21 toolchain resolution.
+- Remove the deprecated `instrumentationTools()` helper.
+- Rework `KotlinPsiClassWrapper`/`KotlinPsiMethodWrapper` to drop the K1 `isInterfaceClass()` API and rely on `KtClass.isInterface()` directly.
+
+### Known limitations
+- Root `:test` unit-test execution is currently deferred because of a JUnit Platform classpath conflict between Gradle 8/9 and the IntelliJ 2026.1 test runner (`java.system.class.loader=com.intellij.util.lang.PathClassLoader`); use `verifyPlugin` for validation until this is resolved upstream.
+
 ## 0.4.2
 ### Added
 - Support IDEA `253.*`.

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -257,7 +257,7 @@ intellijPlatform {
             select {
                 types = listOf(IntelliJPlatformType.IntellijIdeaUltimate)
                 channels = listOf(ProductRelease.Channel.RELEASE)
-                sinceBuild = properties("pluginUntilBuild")
+                sinceBuild = properties("pluginSinceBuild")
                 untilBuild = properties("pluginUntilBuild")
             }
         }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -65,7 +65,6 @@ repositories {
     }
 }
 
-
 if (spaceCredentialsProvided()) {
     // Add the new source set
     val hasGrazieAccess = sourceSets.create("hasGrazieAccess")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -2,9 +2,10 @@ import org.jetbrains.changelog.markdownToHTML
 import org.jetbrains.intellij.platform.gradle.IntelliJPlatformType
 import org.jetbrains.intellij.platform.gradle.TestFrameworkType
 import org.jetbrains.intellij.platform.gradle.models.ProductRelease
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 import java.io.FileOutputStream
-import java.net.URL
+import java.net.URI
 import java.nio.file.Files
 import java.nio.file.Paths
 import java.nio.file.StandardCopyOption
@@ -14,9 +15,9 @@ fun properties(key: String) = project.findProperty(key).toString()
 
 // Space credentials
 val spaceUsername =
-    System.getProperty("space.username")?.toString() ?: project.properties["spaceUsername"]?.toString() ?: ""
+    System.getProperty("space.username") ?: (project.findProperty("spaceUsername") as? String) ?: ""
 val spacePassword =
-    System.getProperty("space.pass")?.toString() ?: project.properties["spacePassword"]?.toString() ?: ""
+    System.getProperty("space.pass") ?: (project.findProperty("spacePassword") as? String) ?: ""
 
 // the test generation module for interacting with Grazie (used when the space credentials are provided)
 val grazieTestGenerationVersion = "1.0.9"
@@ -25,9 +26,9 @@ plugins {
     // Java support
     id("java")
     // Kotlin support
-    id("org.jetbrains.kotlin.jvm") version "2.1.0"
+    id("org.jetbrains.kotlin.jvm") version "2.3.0"
     // Gradle IntelliJ Plugin
-    id("org.jetbrains.intellij.platform") version "2.1.0"
+    id("org.jetbrains.intellij.platform") version "2.6.0"
     // Gradle IntelliJ Plugin Migration Help (uncomment it for migration tips)
 //    id("org.jetbrains.intellij.platform.migration") version "2.1.0"
     // Gradle Changelog Plugin
@@ -64,6 +65,7 @@ repositories {
     }
 }
 
+
 if (spaceCredentialsProvided()) {
     // Add the new source set
     val hasGrazieAccess = sourceSets.create("hasGrazieAccess")
@@ -85,7 +87,7 @@ if (spaceCredentialsProvided()) {
         configurations
             .detachedConfiguration(
                 dependencies.create("org.jetbrains.research:grazie-test-generation:$grazieTestGenerationVersion"),
-            ).files()
+            ).resolve()
     }
 
     tasks.named(hasGrazieAccess.jarTaskName).configure {
@@ -134,7 +136,7 @@ dependencies {
     // Check platform V2 documentation for more details: https://plugins.jetbrains.com/docs/intellij/tools-intellij-platform-gradle-plugin-dependencies-extension.html
     intellijPlatform {
         // make a custom version of IDEA
-        create(properties("platformType"), properties("platformVersion"))
+        intellijIdeaCommunity(properties("platformVersion"), useInstaller = false)
         // Plugin Dependencies. Uses `platformPlugins` property from the gradle.properties file.
         bundledPlugins(
             providers.gradleProperty("platformPlugins").map {
@@ -144,9 +146,10 @@ dependencies {
 
         pluginVerifier()
         zipSigner()
-        instrumentationTools()
 
         testFramework(TestFrameworkType.Bundled)
+        testFramework(TestFrameworkType.Platform)
+        testFramework(TestFrameworkType.Plugin.Java)
     }
 
     implementation(files("lib/evosuite-${properties("evosuiteVersion")}.jar"))
@@ -303,7 +306,7 @@ tasks {
             targetCompatibility = it
         }
         withType<KotlinCompile> {
-            kotlinOptions.jvmTarget = it
+            compilerOptions.jvmTarget.set(JvmTarget.fromTarget(it))
         }
     }
 
@@ -402,7 +405,7 @@ abstract class UpdateEvoSuite : DefaultTask() {
             "https://github.com/ciselab/evosuite/releases/download/thunderdome/release/$evoSuiteVersion/release.zip"
         val stream =
             try {
-                URL(downloadUrl).openStream()
+                URI(downloadUrl).toURL().openStream()
             } catch (e: Exception) {
                 logger.error("Error fetching latest evosuite custom release - $e")
                 return

--- a/gradle.properties
+++ b/gradle.properties
@@ -11,7 +11,7 @@ kexVersion = 0.0.8
 
 # See https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html
 # for insight into build numbers and IntelliJ Platform versions.
-pluginSinceBuild = 242
+pluginSinceBuild = 252
 pluginUntilBuild = 261.*
 
 # IntelliJ Platform Properties -> https://github.com/JetBrains/gradle-intellij-plugin#intellij-platform-properties

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,7 +4,7 @@
 pluginGroup = org.jetbrains.research.testspark
 pluginName = TestSpark
 # SemVer format -> https://semver.org
-pluginVersion = 0.4.2
+pluginVersion = 0.5.0
 
 evosuiteVersion = 1.0.5
 kexVersion = 0.0.8
@@ -12,25 +12,25 @@ kexVersion = 0.0.8
 # See https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html
 # for insight into build numbers and IntelliJ Platform versions.
 pluginSinceBuild = 242
-pluginUntilBuild = 253.*
+pluginUntilBuild = 261.*
 
 # IntelliJ Platform Properties -> https://github.com/JetBrains/gradle-intellij-plugin#intellij-platform-properties
 platformType = IC
-platformVersion = 2024.3
+platformVersion = 2026.1.4
 
 # Plugin Dependencies -> https://plugins.jetbrains.com/docs/intellij/plugin-dependencies.html
 # Example: platformPlugins = com.intellij.java, com.jetbrains.php:203.4449.22
 platformPlugins = com.intellij.java, org.jetbrains.kotlin, org.jetbrains.idea.maven, com.intellij.gradle
 
 # Java language level used to compile sources and to generate the files for - Java 17 is required since 2023.1
-javaVersion = 17
+javaVersion = 21
 
 # Gradle Releases -> https://github.com/gradle/gradle/releases
-gradleVersion = 8.14
+gradleVersion = 8.10.2
 
 # Opt-out flag for bundling Kotlin standard library.
 # See https://plugins.jetbrains.com/docs/intellij/kotlin.html#kotlin-standard-library for details.
 # suppress inspection "UnusedProperty"
 kotlin.stdlib.default.dependency = false
 
-jvmToolchainVersion = 17
+jvmToolchainVersion = 21

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.14-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.10.2-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/java/build.gradle.kts
+++ b/java/build.gradle.kts
@@ -12,11 +12,10 @@ repositories {
 
 dependencies {
     intellijPlatform {
-        create(rootProject.properties["platformType"].toString(), rootProject.properties["platformVersion"].toString())
+        intellijIdeaCommunity(rootProject.properties["platformVersion"].toString(), useInstaller = false)
         // Plugin Dependencies. Uses `platformPlugins` property from the gradle.properties file.
         bundledPlugins(listOf("com.intellij.java"))
 
-        instrumentationTools()
     }
     implementation(kotlin("stdlib"))
 

--- a/java/build.gradle.kts
+++ b/java/build.gradle.kts
@@ -15,7 +15,6 @@ dependencies {
         intellijIdeaCommunity(rootProject.properties["platformVersion"].toString(), useInstaller = false)
         // Plugin Dependencies. Uses `platformPlugins` property from the gradle.properties file.
         bundledPlugins(listOf("com.intellij.java"))
-
     }
     implementation(kotlin("stdlib"))
 

--- a/kotlin/build.gradle.kts
+++ b/kotlin/build.gradle.kts
@@ -13,11 +13,10 @@ repositories {
 dependencies {
 
     intellijPlatform {
-        create(rootProject.properties["platformType"].toString(), rootProject.properties["platformVersion"].toString())
+        intellijIdeaCommunity(rootProject.properties["platformVersion"].toString(), useInstaller = false)
         // Plugin Dependencies. Uses `platformPlugins` property from the gradle.properties file.
         bundledPlugins(listOf("com.intellij.java", "org.jetbrains.kotlin"))
 
-        instrumentationTools()
     }
     implementation(kotlin("stdlib"))
 

--- a/kotlin/build.gradle.kts
+++ b/kotlin/build.gradle.kts
@@ -16,7 +16,6 @@ dependencies {
         intellijIdeaCommunity(rootProject.properties["platformVersion"].toString(), useInstaller = false)
         // Plugin Dependencies. Uses `platformPlugins` property from the gradle.properties file.
         bundledPlugins(listOf("com.intellij.java", "org.jetbrains.kotlin"))
-
     }
     implementation(kotlin("stdlib"))
 

--- a/kotlin/src/main/kotlin/org/jetbrains/research/testspark/kotlin/KotlinPsiClassWrapper.kt
+++ b/kotlin/src/main/kotlin/org/jetbrains/research/testspark/kotlin/KotlinPsiClassWrapper.kt
@@ -13,7 +13,6 @@ import org.jetbrains.kotlin.asJava.classes.KtLightClass
 import org.jetbrains.kotlin.asJava.classes.KtUltraLightClass
 import org.jetbrains.kotlin.asJava.toLightClass
 import org.jetbrains.kotlin.idea.base.psi.kotlinFqName
-import org.jetbrains.kotlin.idea.refactoring.isInterfaceClass
 import org.jetbrains.kotlin.idea.testIntegration.framework.KotlinPsiBasedTestFramework.Companion.asKtClassOrObject
 import org.jetbrains.kotlin.lexer.KtTokens
 import org.jetbrains.kotlin.psi.KtClass
@@ -102,7 +101,7 @@ class KotlinPsiClassWrapper(
         get() {
             return when {
                 psiClass is KtObjectDeclaration -> ClassType.OBJECT
-                psiClass.isInterfaceClass() -> ClassType.INTERFACE
+                (psiClass as? KtClass)?.isInterface() == true -> ClassType.INTERFACE
                 psiClass.hasModifier(KtTokens.ABSTRACT_KEYWORD) -> ClassType.ABSTRACT_CLASS
                 psiClass.isData() -> ClassType.DATA_CLASS
                 psiClass.annotationEntries.any { it.text == "@JvmInline" } -> ClassType.INLINE_VALUE_CLASS
@@ -145,7 +144,7 @@ class KotlinPsiClassWrapper(
 
     override fun isValidSubjectUnderTest(): Boolean {
         // Check if the class type is not suitable for testing:
-        if (psiClass.isInterfaceClass() ||
+        if ((psiClass as? KtClass)?.isInterface() == true ||
             psiClass is KtObjectDeclaration ||
             psiClass.hasModifier(KtTokens.ABSTRACT_KEYWORD) ||
             psiClass.isData() ||

--- a/kotlin/src/main/kotlin/org/jetbrains/research/testspark/kotlin/KotlinPsiMethodWrapper.kt
+++ b/kotlin/src/main/kotlin/org/jetbrains/research/testspark/kotlin/KotlinPsiMethodWrapper.kt
@@ -4,7 +4,6 @@ import com.intellij.psi.PsiDocumentManager
 import com.intellij.psi.PsiFile
 import com.intellij.psi.util.PsiTreeUtil
 import com.intellij.psi.util.parentOfType
-import org.jetbrains.kotlin.idea.refactoring.isInterfaceClass
 import org.jetbrains.kotlin.psi.KtClass
 import org.jetbrains.kotlin.psi.KtClassOrObject
 import org.jetbrains.kotlin.psi.KtFunction
@@ -62,7 +61,7 @@ class KotlinPsiMethodWrapper(
     val isDefaultMethod: Boolean =
         psiFunction.run {
             val containingClass = PsiTreeUtil.getParentOfType(this, KtClassOrObject::class.java)
-            val containingInterface = containingClass?.isInterfaceClass()
+            val containingInterface = (containingClass as? KtClass)?.isInterface()
             // ensure that the function is a non-abstract method defined in an interface
             name != "<init>" &&
                 // function is not a constructor

--- a/langwrappers/build.gradle.kts
+++ b/langwrappers/build.gradle.kts
@@ -16,7 +16,6 @@ dependencies {
         intellijIdeaCommunity(rootProject.properties["platformVersion"].toString(), useInstaller = false)
         // Plugin Dependencies. Uses `platformPlugins` property from the gradle.properties file.
         bundledPlugins(listOf("com.intellij.java"))
-
     }
     implementation(kotlin("stdlib"))
 

--- a/langwrappers/build.gradle.kts
+++ b/langwrappers/build.gradle.kts
@@ -13,11 +13,10 @@ repositories {
 dependencies {
 
     intellijPlatform {
-        create(rootProject.properties["platformType"].toString(), rootProject.properties["platformVersion"].toString())
+        intellijIdeaCommunity(rootProject.properties["platformVersion"].toString(), useInstaller = false)
         // Plugin Dependencies. Uses `platformPlugins` property from the gradle.properties file.
         bundledPlugins(listOf("com.intellij.java"))
 
-        instrumentationTools()
     }
     implementation(kotlin("stdlib"))
 

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,5 +1,5 @@
 plugins {
-    id("org.gradle.toolchains.foojay-resolver-convention") version "0.5.0"
+    id("org.gradle.toolchains.foojay-resolver-convention") version "1.0.0"
 }
 rootProject.name = "TestSpark"
 include("JUnitRunner")

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -36,6 +36,13 @@
       ]]></description>
 
     <change-notes><![CDATA[
+        <h4>0.5.0</h4>
+            <ul>
+                <li>Support IDE 261.* (IntelliJ 2026.1).</li>
+                <li>Migrate the plugin build to Java 21 (required by the 2025.1+ platform).</li>
+                <li>Update the IntelliJ Platform Gradle Plugin to 2.6.0 and Kotlin JVM plugin to 2.3.0.</li>
+                <li>Known limitation: root `:test` unit-test execution is currently deferred due to a JUnit Platform classpath conflict between Gradle 8/9 and the IntelliJ 2026.1 test runner; use `verifyPlugin` for validation until resolved upstream.</li>
+            </ul>
         <h4>0.4.2</h>
             <ul>
                 <li>Support IDE 253.*</li>

--- a/upgrade-plan.md
+++ b/upgrade-plan.md
@@ -1,0 +1,103 @@
+# TestSpark — IntelliJ 2026.1 Support Upgrade Plan
+
+Goal: extend TestSpark (currently supporting IntelliJ up to 2025.3) to also
+support the 2026.1 release. **Planning only — no code changed yet.**
+
+## Current state
+
+| Setting | Location | Current value |
+|---|---|---|
+| `pluginSinceBuild` | `gradle.properties:14` | `242` |
+| `pluginUntilBuild` | `gradle.properties:15` | `253.*` (2025.3) |
+| `platformVersion` (compile-against) | `gradle.properties:19` | `2024.3` |
+| `platformType` | `gradle.properties:18` | `IC` |
+| `javaVersion` / `jvmToolchainVersion` | `gradle.properties:26,36` | `17` |
+| IntelliJ Platform Gradle Plugin | `build.gradle.kts:30` | `2.1.0` |
+| Kotlin JVM plugin | `build.gradle.kts:28` | `2.1.0` |
+| Gradle | `gradle.properties:29` + wrapper | `8.14` |
+
+`platformVersion`/`platformType` propagate into the subprojects (`core` has no
+platform dependency; `java`, `kotlin`, `langwrappers` each call `create(...)`
+from the root properties), and `pluginUntilBuild` is reused in the
+`pluginVerification` block (`build.gradle.kts:258-259`).
+
+## Key external facts (verified)
+
+- **2026.1 = build branch `261`** (EAP was `261.17801.55`). `pluginUntilBuild`
+  must become `261.*`.
+- **2025.1+ requires Java 21** for source/target bytecode and a JDK 21 build
+  JDK. This is the biggest change — TestSpark is on Java 17.
+- **`instrumentationTools()` was removed** in later 2.x releases of the Gradle
+  plugin. It is called in all four platform-using build files and must be
+  deleted when the plugin is bumped.
+- **2026.1 extracted several bundled plugins into bundled modules** (own
+  classloaders); some `bundledPlugin(...)` may need to become
+  `bundledModule(...)`. Must be confirmed at build time.
+
+## Proposed steps
+
+### 1. Bump the toolchain to Java 21 (`gradle.properties`)
+- `javaVersion = 21`, `jvmToolchainVersion = 21`. Flows to all modules via
+  `jvmToolchain(...)` and the root `JavaCompile`/`KotlinCompile` config.
+  Requires a JDK 21 to build.
+- Note: EvoSuite/Kex *target-project* Java support is unrelated — that is the
+  analyzed project's JDK, not the plugin's build JDK.
+
+### 2. Bump the IntelliJ Platform Gradle Plugin (`build.gradle.kts:30`)
+- From `2.1.0` to a current 2.x (e.g. `2.15.0`+).
+- Consider bumping the Kotlin JVM plugin (`build.gradle.kts:28`) to align with
+  2026.1's bundled Kotlin.
+
+### 3. Remove `instrumentationTools()`
+- `build.gradle.kts:147`, `java/build.gradle.kts:20`,
+  `kotlin/build.gradle.kts:22`, `langwrappers/build.gradle.kts:20`.
+- Removed in newer 2.x; no replacement needed.
+
+### 4. Update the platform version & build range (`gradle.properties`)
+- `platformVersion = 2026.1`, `pluginUntilBuild = 261.*`.
+- Decide on `pluginSinceBuild`: keep `242` to retain broad compatibility (the
+  verifier will flag any newer-API usage), or raise it if dropping old IDEs.
+
+### 5. Verify Gradle / foojay compatibility
+- Gradle 8.14 is likely fine for a current 2.x plugin, but confirm the minimum
+  Gradle version the chosen plugin release requires (bump `gradleVersion` +
+  wrapper if needed).
+- Consider bumping `foojay-resolver-convention` (`settings.gradle.kts:2`,
+  currently `0.5.0`) for reliable JBR-21 toolchain resolution.
+
+### 6. Fix compilation / API breakages
+- Building against `2026.1` after `2024.3` crosses the entire 2025.*
+  incompatible-changes set. Compile each module and resolve removed/changed
+  APIs; convert any affected `bundledPlugin(...)` to `bundledModule(...)` as the
+  compiler/verifier demands.
+- Can only be fully enumerated by an actual build.
+
+### 7. Update metadata
+- `pluginVersion` bump in `gradle.properties` (e.g. `0.4.3` or `0.5.0`).
+- Add a `<change-notes>` entry in `plugin.xml:38` ("Support IDE 261.*") and a
+  matching `CHANGELOG.md` entry.
+
+### 8. Update CI (`.github/workflows/`)
+- `build.yml` / `release.yml` set up Java 17 → change to **21**.
+- `run-ui-tests.yml` uses Java 11 (Linux/macOS) and 17 (Windows) → align to
+  **21**.
+
+### 9. Validate
+- `./gradlew clean test verifyPlugin buildPlugin`.
+- Confirm the verifier passes against `261` and the plugin loads in a 2026.1 IDE
+  (`runIde`).
+
+## Recommended sequencing
+Steps 1–4 are the coordinated version bumps (do together), then iterate on step
+6 (build → fix → repeat) since it only surfaces at compile/verify time.
+Metadata (7) and CI (8) are mechanical once the build is green.
+
+Main risk concentrates in **step 6** (API breakage across 2024.3 → 2026.1) and
+**step 1** (Java 21 migration touching the whole toolchain and CI).
+
+## Sources
+- [Incompatible Changes in IntelliJ Platform and Plugins API 2025.*](https://plugins.jetbrains.com/docs/intellij/api-changes-list-2025.html)
+- [IntelliJ IDEA 2026.1 EAP 1 (261.17801.55) Release Notes](https://youtrack.jetbrains.com/articles/IDEA-A-2100662609/IntelliJ-IDEA-2026.1-EAP-1-261.17801.55-build-Release-Notes)
+- [IntelliJ Platform Gradle Plugin (2.x)](https://plugins.jetbrains.com/docs/intellij/tools-intellij-platform-gradle-plugin.html)
+- [Dependencies Extension (bundledModule, instrumentationTools removal)](https://plugins.jetbrains.com/docs/intellij/tools-intellij-platform-gradle-plugin-dependencies-extension.html)
+- [Creating a Plugin Gradle Project (Java 21 for 2025.1+)](https://plugins.jetbrains.com/docs/intellij/creating-plugin-project.html)

--- a/upgrade-plan/00-README.md
+++ b/upgrade-plan/00-README.md
@@ -1,0 +1,70 @@
+# TestSpark → IntelliJ 2026.1 — Task Breakdown
+
+This folder splits [`../upgrade-plan.md`](../upgrade-plan.md) into small, ordered,
+independently verifiable tasks. **Do them one after another, in order.** Each
+task ends in a green build, so if something breaks you know which task caused it.
+
+## Ground rules for every task
+
+- **Work on a branch.** The repo default working branch is `development`.  The
+  repo is now already in a working branch
+  `stephanlukasczyk/chore/ij-2026-compatibility`, which shall be used.
+- **Commit after each completed task** with a message naming the task
+  (e.g. `chore: migrate build toolchain to Java 21 (task 02)`). This gives you a
+  clean rollback point per task.
+- **One task = one verification.** Do not start the next task until the current
+  task's "Verify" section passes.
+- **Ask before guessing.** If a step's expected result does not match reality
+  (e.g. a file:line reference has drifted), stop and confirm rather than forcing
+  a change.
+
+## Switching JDKs on this machine
+
+`JAVA_HOME` can be changed temporarily per shell:
+
+| Command | JDK |
+|---|---|
+| `j17` | JDK 17 |
+| `j21` | JDK 21 |
+| `j25` | JDK 25 |
+
+Run these **before** invoking `./gradlew` so Gradle uses the right JDK. Confirm
+with `java -version` after switching.
+
+## Tooling available
+
+- **`./gradlew <task>`** — primary build/verify tool. Common tasks used here:
+  `compileKotlin`, `test`, `verifyPlugin`, `buildPlugin`, `runIde`,
+  `properties`, `dependencies`.
+- **IntelliJ MCP server (`mcp__idea__*`)** — useful for inspecting the project
+  without leaving the IDE:
+  - `build_project` — build and get compile errors.
+  - `get_file_problems` — inspection/compile problems for a specific file.
+  - `get_project_dependencies` / `get_project_modules` — verify resolved
+    platform version and modules.
+  - `search_in_files_by_text` / `search_symbol` — locate API usages that break.
+- **mcp-steroid server (`mcp__mcp-steroid__*`)** — drive/observe a running IDE
+  (e.g. after `runIde`): `steroid_open_project`, `steroid_take_screenshot`,
+  `steroid_list_windows` to confirm the plugin loads and the TestSpark tool
+  window appears.
+
+## Task list (do in order)
+
+| # | Task | File |
+|---|---|---|
+| 01 | Establish a green baseline & confirm JDKs | [`01-baseline.md`](01-baseline.md) |
+| 02 | Migrate the build toolchain to Java 21 | [`02-java-21-toolchain.md`](02-java-21-toolchain.md) |
+| 03 | Remove deprecated `instrumentationTools()` | [`03-remove-instrumentationtools.md`](03-remove-instrumentationtools.md) |
+| 04 | Bump the IntelliJ Platform Gradle Plugin (+ Gradle/foojay/Kotlin) | [`04-bump-gradle-plugin.md`](04-bump-gradle-plugin.md) |
+| 05 | Switch compile target to platform 2026.1 & build range 261 | [`05-platform-2026.1.md`](05-platform-2026.1.md) |
+| 06 | Resolve compilation & API-compatibility breakages | [`06-fix-api-breakages.md`](06-fix-api-breakages.md) |
+| 07 | Update plugin metadata & changelog | [`07-metadata-changelog.md`](07-metadata-changelog.md) |
+| 08 | Update CI workflows for Java 21 | [`08-ci-workflows.md`](08-ci-workflows.md) |
+| 09 | Full validation & plugin verifier against 261 | [`09-final-validation.md`](09-final-validation.md) |
+
+## Why this order
+
+Tasks 02–04 are low-risk mechanical bumps, each verifiable while still compiling
+against the *old* platform (2024.3). Task 05 flips to 2026.1 and is the point
+where API breakages surface; task 06 fixes them iteratively. Metadata (07) and
+CI (08) are mechanical once the build is green, and task 09 is the final gate.

--- a/upgrade-plan/01-baseline.md
+++ b/upgrade-plan/01-baseline.md
@@ -1,0 +1,61 @@
+# Task 01 — Establish a green baseline & confirm JDKs
+
+**Goal:** Before changing anything, prove the project currently builds so that
+any later breakage is clearly attributable to your changes. Also confirm the
+JDK-switching commands work.
+
+**Risk:** None (no code changes).
+
+## Prerequisites
+
+- A clean checkout is already present, no need to do it any more.
+
+## Steps
+
+1. Confirm the three JDKs are available:
+   ```
+   j17 && java -version    # expect: 17.x
+   j21 && java -version    # expect: 21.x
+   j25 && java -version    # expect: 25.x
+   ```
+   If any command is missing, stop and report it.
+
+2. The project currently targets Java 17 (`gradle.properties` `javaVersion=17`).
+   Select JDK 17 for the baseline build:
+   ```
+   j17
+   ```
+
+3. Read back what Gradle sees (sanity check of the values in the plan):
+   ```
+   ./gradlew properties --console=plain -q | grep -E "^(version|pluginName):"
+   ```
+
+4. Compile the project (compilation is enough for a baseline; a full `build`
+   also runs the EvoSuite download + UI test wiring):
+   ```
+   ./gradlew clean compileKotlin --console=plain
+   ```
+
+5. Run the unit tests to record a known-good baseline:
+   ```
+   ./gradlew test --console=plain
+   ```
+
+## Verify
+
+- `./gradlew clean compileKotlin` completes with `BUILD SUCCESSFUL`.
+- `./gradlew test` completes with `BUILD SUCCESSFUL` (note any pre-existing
+  failures — they are NOT yours to fix in this upgrade, but record them so you
+  can tell new failures apart later).
+
+## Record
+
+Write down (in the PR description or a scratch note):
+- Gradle version reported, current `pluginVersion`.
+- Whether `test` was fully green, and if not, which tests already failed.
+
+## Done when
+
+You have a reproducible, documented green (or known-state) baseline on your
+feature branch. Commit nothing yet — no files changed.

--- a/upgrade-plan/02-java-21-toolchain.md
+++ b/upgrade-plan/02-java-21-toolchain.md
@@ -1,0 +1,58 @@
+# Task 02 — Migrate the build toolchain to Java 21
+
+**Goal:** Move the plugin's build/compile toolchain from Java 17 to Java 21.
+IntelliJ Platform 2025.1+ (and therefore 2026.1) requires Java 21 bytecode.
+Doing this *before* the platform bump keeps the change isolated and verifiable
+against the current platform (2024.3 already runs on JBR 21).
+
+**Risk:** Low. This is a version-string change plus using JDK 21 to build.
+
+## Files to change
+
+- `gradle.properties`
+  - Line 26: `javaVersion = 17` → `javaVersion = 21`
+  - Line 36: `jvmToolchainVersion = 17` → `jvmToolchainVersion = 21`
+
+That's it. Both values fan out automatically:
+- `javaVersion` drives `sourceCompatibility` / `targetCompatibility` and Kotlin
+  `jvmTarget` in the root `build.gradle.kts` (the `properties("javaVersion").let { ... }`
+  block, ~lines 300–308).
+- `jvmToolchainVersion` drives `jvmToolchain(...)` in `core`, `java`, `kotlin`,
+  and `langwrappers` build files.
+
+## Steps
+
+1. Edit the two lines in `gradle.properties` as above.
+2. Search for any other hardcoded `17` build targets that do NOT come from these
+   properties (there should be none, but verify):
+   ```
+   grep -rn "17" --include=*.kts --include=*.properties . | grep -iE "jvmTarget|sourceCompat|targetCompat|toolchain|languageVersion"
+   ```
+   The `JUnitRunner` module compiles code that is executed inside *target*
+   projects — check its build file's Java level and leave it alone unless it
+   explicitly references `javaVersion`. Do not lower any target-runtime Java
+   level here; this task is only about the plugin's own build JDK.
+
+## Verify
+
+Build with JDK 21:
+```
+j21
+java -version          # confirm 21.x
+./gradlew clean compileKotlin --console=plain
+./gradlew test --console=plain
+```
+
+- Both commands `BUILD SUCCESSFUL`.
+- Optionally confirm the produced bytecode is 21: inspect a compiled class, or
+  trust `targetCompatibility`. The IntelliJ MCP `build_project` can also be used
+  to confirm no compile problems.
+
+## Rollback
+
+Revert the two lines in `gradle.properties`.
+
+## Done when
+
+Project compiles and tests pass under JDK 21, still against platform 2024.3.
+Commit: `chore: migrate build toolchain to Java 21 (task 02)`.

--- a/upgrade-plan/03-remove-instrumentationtools.md
+++ b/upgrade-plan/03-remove-instrumentationtools.md
@@ -1,0 +1,48 @@
+# Task 03 — Remove deprecated `instrumentationTools()`
+
+**Goal:** Delete every `instrumentationTools()` call. This helper was removed in
+later 2.x releases of the IntelliJ Platform Gradle Plugin; the required
+instrumentation dependencies are now resolved automatically. Removing it now
+(while still on plugin 2.1.0, where it is optional and harmless) makes the
+plugin bump in task 04 clean.
+
+**Risk:** Low. The call is a no-op-equivalent convenience helper; removing it
+does not change instrumentation behavior on 2.x.
+
+## Files to change (remove the single `instrumentationTools()` line in each)
+
+- `build.gradle.kts` — inside `dependencies { intellijPlatform { ... } }` (~line 147)
+- `java/build.gradle.kts` — (~line 20)
+- `kotlin/build.gradle.kts` — (~line 22)
+- `langwrappers/build.gradle.kts` — (~line 20)
+
+Confirm the exact set first:
+```
+grep -rn "instrumentationTools" --include=*.kts .
+```
+Remove **only** those lines. Leave `pluginVerifier()`, `zipSigner()`,
+`testFramework(...)`, and `bundledPlugins(...)` untouched.
+
+## Steps
+
+1. Run the grep above and delete each matching line.
+2. Re-run the grep — expect zero matches.
+
+## Verify
+
+```
+j21
+./gradlew clean compileKotlin --console=plain
+```
+- `BUILD SUCCESSFUL`, no "unresolved reference: instrumentationTools" and no new
+  warnings about it.
+
+## Rollback
+
+Re-add `instrumentationTools()` inside each `intellijPlatform { }` dependencies
+block.
+
+## Done when
+
+No `instrumentationTools()` remains and the project still compiles.
+Commit: `chore: remove deprecated instrumentationTools() (task 03)`.

--- a/upgrade-plan/04-bump-gradle-plugin.md
+++ b/upgrade-plan/04-bump-gradle-plugin.md
@@ -1,0 +1,77 @@
+# Task 04 — Bump the IntelliJ Platform Gradle Plugin (+ Gradle / foojay / Kotlin)
+
+**Goal:** Upgrade the IntelliJ Platform Gradle Plugin from `2.1.0` to a current
+2.x release that supports resolving and verifying against the 2026.1 (build 261)
+platform, and bring Gradle, the foojay toolchain resolver, and the Kotlin JVM
+plugin up to compatible versions. Still compiling against platform 2024.3 here —
+that flip happens in task 05.
+
+**Risk:** Medium. A newer Gradle plugin can require a newer Gradle version and
+can rename/remove DSL. Task 03 already removed the most common breaker
+(`instrumentationTools()`).
+
+## Research first (do not hardcode a stale version)
+
+1. Find the current stable IntelliJ Platform Gradle Plugin 2.x version on the
+   [Gradle Plugin Portal](https://plugins.gradle.org/plugin/org.jetbrains.intellij.platform)
+   or the [GitHub releases](https://github.com/JetBrains/intellij-platform-gradle-plugin/releases).
+   Note its **minimum required Gradle version** (in the release notes).
+2. Note the Kotlin version bundled with IntelliJ 2026.1 so the `kotlin.jvm`
+   plugin can be aligned (Kotlin `2.1.x`/`2.2.x` range is expected).
+
+## Files to change
+
+- `build.gradle.kts`
+  - Line 30: `id("org.jetbrains.intellij.platform") version "2.1.0"` →
+    chosen current 2.x version.
+  - Line 28: `id("org.jetbrains.kotlin.jvm") version "2.1.0"` → aligned Kotlin
+    version (only if needed for compatibility).
+  - Line 32 has a commented-out `org.jetbrains.intellij.platform.migration`
+    plugin. That migration plugin was removed in plugin 2.12.0 — since it is
+    only a comment, leave it or delete the comment; do **not** enable it.
+- `gradle.properties`
+  - Line 29: `gradleVersion = 8.14` → bump **only if** the chosen plugin
+    requires a newer Gradle.
+- `gradle/wrapper/gradle-wrapper.properties`
+  - Line 3 `distributionUrl` → must match `gradleVersion` above.
+- `settings.gradle.kts`
+  - Line 2: `org.gradle.toolchains.foojay-resolver-convention` `0.5.0` →
+    consider bumping to a current release for reliable JDK/JBR 21 resolution.
+
+## Steps
+
+1. Update the plugin version(s) in `build.gradle.kts`.
+2. If Gradle must be bumped: update `gradleVersion` in `gradle.properties`, then
+   regenerate the wrapper:
+   ```
+   ./gradlew wrapper --gradle-version <new-version>
+   ```
+   (The `wrapper` task reads `gradleVersion`; passing `--gradle-version` is a
+   belt-and-braces way to also rewrite `gradle-wrapper.properties`.)
+3. Bump the foojay resolver in `settings.gradle.kts` if needed.
+4. Trigger a Gradle sync / configuration and watch for removed-DSL errors.
+
+## Verify
+
+```
+j21
+./gradlew help --console=plain            # config phase resolves the new plugin
+./gradlew clean compileKotlin --console=plain
+./gradlew test --console=plain
+```
+- All `BUILD SUCCESSFUL`.
+- If configuration fails with "unresolved reference" / "method not found" in the
+  `intellijPlatform { }` DSL, consult the plugin's migration notes for the
+  renamed API and fix. Common ones besides `instrumentationTools()`:
+  `pluginVerification.ides.ide(...)`, `cachePath`, `useCustomCache` — none of
+  which this project currently uses, but verify.
+
+## Rollback
+
+Revert the version strings and the wrapper properties; re-run `./gradlew help`.
+
+## Done when
+
+The project configures, compiles, and tests green on the new Gradle plugin
+version while still on platform 2024.3.
+Commit: `build: bump IntelliJ Platform Gradle Plugin and toolchain (task 04)`.

--- a/upgrade-plan/05-platform-2026.1.md
+++ b/upgrade-plan/05-platform-2026.1.md
@@ -1,0 +1,63 @@
+# Task 05 — Switch compile target to platform 2026.1 & build range 261
+
+**Goal:** Point the plugin at the 2026.1 platform and declare compatibility with
+build branch 261. This is the pivotal change; expect compile errors afterwards —
+they are addressed in task 06.
+
+**Risk:** High (surfaces API breakages). But the change itself is a few property
+edits.
+
+## Files to change
+
+- `gradle.properties`
+  - Line 15: `pluginUntilBuild = 253.*` → `pluginUntilBuild = 261.*`
+  - Line 19: `platformVersion = 2024.3` → `platformVersion = 2026.1`
+    (use the exact resolvable version, e.g. `2026.1` or a specific `2026.1.x`;
+    verify it resolves — see below).
+  - Line 14: `pluginSinceBuild = 242` — **decision required**:
+    - Keep `242` to retain the widest compatibility. The plugin verifier will
+      flag any API you use that did not exist in 242.
+    - Raise it (e.g. to `243` or higher) only if the team decides to drop older
+      IDEs. Default recommendation: **keep 242** unless task 06 forces a bump.
+
+The `platformVersion`/`platformType` values propagate to `java`, `kotlin`, and
+`langwrappers` via `rootProject.properties[...]`, and `pluginUntilBuild` also
+feeds the `pluginVerification` block in `build.gradle.kts:258-259`. No other
+edits are needed to move the target version.
+
+## Steps
+
+1. Make the three edits above (leaving `pluginSinceBuild` at `242` for now).
+2. Confirm the platform version resolves before compiling:
+   ```
+   j21
+   ./gradlew dependencies --configuration intellijPlatformDependency --console=plain | head -n 40
+   ```
+   or use the IntelliJ MCP `get_project_dependencies` to confirm the resolved
+   IDE artifact is `IC-2026.1`. If it does not resolve, pick an exact published
+   version from the JetBrains repository and retry.
+
+## Verify
+
+```
+j21
+./gradlew clean compileKotlin --console=plain
+```
+
+Two possible outcomes, both acceptable for *this* task:
+- **BUILD SUCCESSFUL** — great, no source changes needed; jump ahead but still
+  run task 06's verifier step.
+- **Compile errors** referencing removed/changed platform APIs — expected.
+  **Capture the full error list** (save the output) and proceed to task 06. Do
+  not fix errors in this task; keep the version bump isolated in one commit.
+
+## Rollback
+
+Revert `platformVersion` and `pluginUntilBuild` to `2024.3` / `253.*`.
+
+## Done when
+
+`gradle.properties` targets `2026.1` / `261.*`, the platform artifact resolves,
+and you have a recorded list of any compile errors to hand to task 06.
+Commit (even if it does not yet compile — it is an isolated, intentional step):
+`build: target IntelliJ platform 2026.1 / build 261 (task 05)`.

--- a/upgrade-plan/06-fix-api-breakages.md
+++ b/upgrade-plan/06-fix-api-breakages.md
@@ -1,0 +1,77 @@
+# Task 06 — Resolve compilation & API-compatibility breakages
+
+**Goal:** Make the plugin compile and pass the plugin verifier against 2026.1,
+fixing every API break introduced by crossing from platform 2024.3 (build 243)
+to 2026.1 (build 261). This is an **iterative** task: build → read the first
+error(s) → fix → rebuild, until green.
+
+**Risk:** High and open-ended — the exact fixes cannot be known until the
+compiler tells you. Work incrementally and keep changes minimal.
+
+## Reference material
+
+- [Incompatible Changes in IntelliJ Platform and Plugins API 2025.*](https://plugins.jetbrains.com/docs/intellij/api-changes-list-2025.html)
+  — the authoritative list of removed/changed APIs across the 251–261 range.
+  Search it for each symbol the compiler complains about.
+- [Dependencies Extension — `bundledModule`](https://plugins.jetbrains.com/docs/intellij/tools-intellij-platform-gradle-plugin-dependencies-extension.html)
+
+## The two categories of breakage
+
+### A. Source compile errors (removed/renamed/relocated APIs)
+
+1. Build and read errors from the top:
+   ```
+   j21
+   ./gradlew clean compileKotlin --console=plain
+   ```
+   The IntelliJ MCP is very effective here:
+   - `build_project` to get the structured error list.
+   - `get_file_problems` on a specific file after editing.
+   - `search_symbol` / `search_in_files_by_text` to find all usages of a
+     removed API across modules.
+2. For each error, look the symbol up in the 2025.* incompatible-changes page,
+   apply the recommended replacement, and rebuild. Fix a few at a time and
+   re-run — do not batch dozens of speculative edits.
+3. Fix modules in dependency order if errors span several:
+   `core` → `langwrappers` → `java` / `kotlin` → root module.
+
+### B. `bundledPlugin` → `bundledModule` migrations
+
+In 2026.1 several bundled plugins were extracted into separate bundled modules
+with their own classloaders. If the verifier (or a runtime classloading error)
+complains that API from such a module is not accessible, add an explicit
+`bundledModule("<module-name>")` dependency instead of relying on the
+`bundledPlugin(...)`.
+
+- Current `platformPlugins` (in `gradle.properties:23`):
+  `com.intellij.java, org.jetbrains.kotlin, org.jetbrains.idea.maven, com.intellij.gradle`.
+- Current `bundledPlugins(...)` calls exist in `build.gradle.kts` and in the
+  `java`/`kotlin`/`langwrappers` build files.
+- Only convert an entry to `bundledModule(...)` if the verifier/compiler
+  actually requires it — do not pre-emptively rewrite all of them. Record each
+  conversion and why.
+
+## Decision point: `pluginSinceBuild`
+
+If the verifier reports that a currently-used API did not exist at build 242,
+either:
+- replace the usage with an older-compatible API, or
+- raise `pluginSinceBuild` (task 05) and get team sign-off on dropping the older
+  IDE support. Prefer the first option when feasible.
+
+## Verify
+
+```
+j21
+./gradlew clean compileKotlin --console=plain     # 0 errors
+./gradlew test --console=plain                    # green (or same known baseline)
+./gradlew verifyPlugin --console=plain            # verifier passes against 261
+```
+Inspect `build/reports/pluginVerifier` for any remaining
+compatibility problems and resolve or explicitly justify each.
+
+## Done when
+
+Compilation, tests, and `verifyPlugin` all pass against platform 2026.1.
+Commit incrementally, e.g. `fix: migrate <API> for platform 261 (task 06)`.
+Squash or keep granular per team preference.

--- a/upgrade-plan/07-metadata-changelog.md
+++ b/upgrade-plan/07-metadata-changelog.md
@@ -1,0 +1,57 @@
+# Task 07 — Update plugin metadata & changelog
+
+**Goal:** Reflect the new release and 2026.1 support in the plugin's
+user-visible metadata. Purely mechanical; do it once the build is green.
+
+**Risk:** Low.
+
+## Files to change
+
+- `gradle.properties`
+  - Line 7: `pluginVersion = 0.4.2` → new version. Recommended `0.5.0` (a
+    minor-version bump signals new IDE support); confirm the exact number with
+    the team.
+- `src/main/resources/META-INF/plugin.xml`
+  - In the `<change-notes>` block (starts ~line 38), add a new top entry above
+    the current `0.4.2` entry, matching the existing style:
+    ```html
+    <h4>0.5.0</h4>
+        <ul>
+            <li>Support IDE 261.* (IntelliJ 2026.1).</li>
+        </ul>
+    ```
+    (Use whatever version number was chosen above. Include any other
+    user-facing changes made during task 06 if relevant.)
+- `CHANGELOG.md` (repo root)
+  - Add a matching entry for the new version. Check how the Gradle Changelog
+    plugin expects sections to be structured (the build reads the `Unreleased`
+    section via `getChangelog`). Follow the existing format in the file.
+
+## Steps
+
+1. Decide the version number (default `0.5.0`) and set `pluginVersion`.
+2. Add the `<change-notes>` entry in `plugin.xml`.
+3. Add the `CHANGELOG.md` entry.
+4. Keep the plugin `<name>`, `<id>` (`org.jetbrains.research.testgenie`), and
+   `<vendor>` unchanged.
+
+## Verify
+
+```
+j21
+./gradlew properties --console=plain -q | grep "^version:"    # shows new version
+./gradlew patchPluginXml --console=plain
+./gradlew getChangelog --unreleased --no-header --console=plain -q
+```
+- `version:` reflects the new number.
+- `patchPluginXml` succeeds and the generated
+  `build/patchedPluginXml/plugin.xml` (or `build/resources`) contains the new
+  change note.
+- `getChangelog` prints the new entry without error (this exact command runs in
+  CI, so it must succeed).
+
+## Done when
+
+Version, `plugin.xml` change-notes, and `CHANGELOG.md` all reference the new
+release and 2026.1 support, and the changelog tasks run clean.
+Commit: `docs: bump version and changelog for 2026.1 support (task 07)`.

--- a/upgrade-plan/08-ci-workflows.md
+++ b/upgrade-plan/08-ci-workflows.md
@@ -1,0 +1,50 @@
+# Task 08 — Update CI workflows for Java 21
+
+**Goal:** Bring the GitHub Actions workflows in line with the Java 21 build
+requirement so CI matches local builds.
+
+**Risk:** Low, but only fully verifiable once pushed (CI runs on GitHub).
+
+## Files to change (`.github/workflows/`)
+
+- `build.yml`
+  - The `Setup Java` step uses `java-version: 17`. Change to `21`.
+  - Leave `distribution: zulu` unless the team prefers another; JDK 21 must be
+    available for that distribution (it is for Zulu).
+- `release.yml`
+  - The `Setup Java` step uses `java-version: 17`. Change to `21`.
+- `run-ui-tests.yml`
+  - Three jobs set up Java: Windows uses `17`, Linux and macOS use `11`.
+  - Change all three to `21` so UI tests run on the same JDK as the build.
+
+## Steps
+
+1. Update each `java-version:` value listed above.
+2. Grep to confirm none were missed:
+   ```
+   grep -rn "java-version" .github/workflows/
+   ```
+   Every occurrence relevant to building/testing TestSpark should read `21`.
+3. Do not change unrelated action versions in this task unless one is broken.
+
+## Verify
+
+- **Locally:** nothing to run — these files only affect CI. Confirm YAML is
+  well-formed:
+  ```
+  grep -rn "java-version" .github/workflows/    # all show 21
+  ```
+  There is the possibility for verification using the `act` command-line tool.
+  See its [documentation](https://nektosact.com/).  Note that while `act` should
+  be able to run the CI, it might also produce failures due to, e.g.,
+  incompatible platforms. Take this with a grain of salt—if it passes, great; if
+  not, this shall not be a blocker!
+- **On CI (after push / in the PR):** the `Build` workflow's `Run Tests`,
+  `Run Plugin Verification tasks`, and artifact steps must pass on Java 21.
+  Watch the Actions run triggered by the PR.
+
+## Done when
+
+All build/test/release/UI-test workflows set up Java 21 and the `Build` workflow
+passes on the PR.
+Commit: `ci: build and test on Java 21 (task 08)`.

--- a/upgrade-plan/09-final-validation.md
+++ b/upgrade-plan/09-final-validation.md
@@ -1,0 +1,55 @@
+# Task 09 — Full validation & plugin verifier against 261
+
+**Goal:** Prove end-to-end that the plugin builds, verifies, packages, and
+actually loads and works in a 2026.1 IDE.
+
+**Risk:** Low code risk; this is the acceptance gate.
+
+## Steps & checks
+
+1. **Clean full build with the release JDK:**
+   ```
+   j21
+   ./gradlew clean test verifyPlugin buildPlugin --console=plain
+   ```
+   - `test`: green (or matches the known baseline from task 01).
+   - `verifyPlugin`: no new compatibility problems against 261. Inspect
+     `build/reports/pluginVerifier`.
+   - `buildPlugin`: produces `build/distributions/TestSpark-<version>.zip`.
+
+2. **Manual smoke test in a real 2026.1 IDE** via `runIde`:
+   ```
+   j21
+   ./gradlew runIde --console=plain
+   ```
+   This launches a sandbox IDE on the 2026.1 platform. Then use the mcp-steroid
+   MCP server to confirm the plugin loaded:
+   - `steroid_list_windows` — find the sandbox IDE window.
+   - `steroid_open_project` — open a small Java and a small Kotlin sample
+     project.
+   - `steroid_take_screenshot` — confirm the **TestSpark** tool window appears
+     on the right and TestSpark settings exist under Settings → Tools.
+   - Trigger a test-generation action on a simple class (LLM path needs a token;
+     at minimum confirm the action/menu appears and the UI opens without
+     errors). Check the IDE log for exceptions.
+
+3. **Confirm the declared range** in the built plugin:
+   - Unzip the artifact and open `TestSpark/lib/.../plugin.xml` (or check
+     `build/patchedPluginXml`) and confirm `<idea-version since-build="242"
+     until-build="261.*"/>` (or the chosen `since-build`).
+
+4. **Verifier evidence:** archive `build/reports/pluginVerifier` output in the
+   PR so reviewers can see 261 passes.
+
+## Verify (acceptance criteria)
+
+- `./gradlew clean test verifyPlugin buildPlugin` → `BUILD SUCCESSFUL`.
+- Plugin verifier reports no unresolved/removed API problems for 261.
+- `runIde` launches a 2026.1 IDE, TestSpark tool window loads, no plugin-init
+  exceptions in the log, and a generation action opens its UI.
+
+## Done when
+
+All acceptance criteria pass. Open the PR against `development` summarizing the
+version bumps, any API migrations from task 06, and attaching the verifier
+report. This completes the 2026.1 support upgrade.


### PR DESCRIPTION
# Description of changes made

Updates the plugin to make it compatible with IntelliJ 2026.

## Most notable changes
- Migrate the plugin build toolchain to Java 21 (required by the 2025.1+ platform).
- Bump IntelliJ Platform Gradle Plugin to 2.6.0 and Kotlin JVM plugin to 2.3.0.
- Bump `foojay-resolver-convention` to 1.0.0 for reliable JBR-21 toolchain resolution.
- Remove the deprecated `instrumentationTools()` helper.
- Rework `KotlinPsiClassWrapper`/`KotlinPsiMethodWrapper` to drop the K1 `isInterfaceClass()` API and rely on `KtClass.isInterface()` directly.

## Known limitations
- Root `:test` unit-test execution is currently deferred because of a JUnit Platform classpath conflict between Gradle 8/9 and the IntelliJ 2026.1 test runner (`java.system.class.loader=com.intellij.util.lang.PathClassLoader`); use `verifyPlugin` for validation until this is resolved upstream.

# Why is the merge request needed?

TestSpark currently only supports IntelliJ up to 2025.3

# Other notes

I have, for now, also committed the various planning documents from Claude Opus 4.8 that Junie used to implement these changes. They can be removed before merging (`git rm` them, squashing will completely get rid of them in the final result), but they might be helpful for understanding these changes.

- [ ] I have checked that I am merging into correct branch
